### PR TITLE
Edits for compatability with aws-otel-collector v13

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -13,6 +13,9 @@ exporters:
     region: us-west-2
 
 service:
+  telemetry:
+    logs:
+      level: debug
   pipelines:
     traces:
       receivers:

--- a/integration-test-app/docker-compose.yml
+++ b/integration-test-app/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   otel:
     image: amazon/aws-otel-collector:latest
-    command: --config /config/collector-config-local.yml --log-level debug
+    command: --config /config/collector-config-local.yml
     volumes:
       - .:/config
     environment:


### PR DESCRIPTION
# Description

With the release of `public.ecr.aws/aws-observability/aws-otel-collector:latest` `v13`, we need to update our workflows to be compatible with it.

Specifically we remove the `--log-level` flag to fix the `integration-testing.yml` build.