### PR TITLE
Remove log-level flag everywhere for collector

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   otel:
     image: amazon/aws-otel-collector:latest
-    command: --config /config/collector-config.yml --log-level debug
+    command: --config /config/collector-config.yml
     volumes:
       - .:/config
     environment:


### PR DESCRIPTION
Follow up to #8 which removed some but not all of the `--log-level` flags now that the image upstream has been updated.