### PR TITLE
Increase points to alarm for memory usage poll

### DIFF
--- a/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
+++ b/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__file__)
 # AWS Client API Constants
 
 COMMON_ALARM_API_PARAMETERS = {
-    "EvaluationPeriods": 4,
-    "DatapointsToAlarm": 3,
+    "EvaluationPeriods": 5,
+    "DatapointsToAlarm": 5,
     "ComparisonOperator": "GreaterThanOrEqualToThreshold",
     "TreatMissingData": "ignore",
 }


### PR DESCRIPTION
# Description

We have now seen multiple false alarms trigger the automatic publishing of issues in #14 and #15. We know these are false alarms because we are looking for **sustained excessive memory usage** in the form of memory leaks where the memory goes up and _never comes back down_.

As such, we increase the data points to alarm to be 5 out of 5 points. This translates to 5 x 10 minutes = 50 minutes of sustained memory usage _above_ the threshold (in this case 16 GiB). Increasing it to be more shouldn't be a problem, but we'll leave at 5 for now.

This will require updating the other language repos because we don't have the Soak Tests as a centralized action yet (and we ant to maintain consistency among the repos as much as possible).

Fixes #14 
Fixes #15