### PR TITLE
Use upstream benchmark action + update issues when names match

### DIFF
--- a/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
+++ b/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
@@ -68,33 +68,31 @@ if __name__ == "__main__":
     )["MetricDataResults"]
 
     benchmarks_json = json.dumps(
-        {
-            "benchmarks": [
-                {
-                    "Name": "Soak Test Average CPU Load",
-                    "Value": mean(
-                        next(
-                            metric_data
-                            for metric_data in metric_data_results
-                            if metric_data["Id"] == "cpu_load_expr"
-                        )["Values"]
-                    ),
-                    "Unit": "Percent",
-                },
-                {
-                    "Name": "Soak Test Average Virtual Memory Used",
-                    "Value": mean(
-                        next(
-                            metric_data
-                            for metric_data in metric_data_results
-                            if metric_data["Id"] == "total_memory_expr"
-                        )["Values"]
-                    )
-                    / (2 ** 20),
-                    "Unit": "Megabytes",
-                },
-            ]
-        },
+        [
+            {
+                "name": "Soak Test Average CPU Load",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "cpu_load_expr"
+                    )["Values"]
+                ),
+                "unit": "Percent",
+            },
+            {
+                "name": "Soak Test Average Virtual Memory Used",
+                "value": mean(
+                    next(
+                        metric_data
+                        for metric_data in metric_data_results
+                        if metric_data["Id"] == "total_memory_expr"
+                    )["Values"]
+                )
+                / (2 ** 20),
+                "unit": "Megabytes",
+            },
+        ],
         indent=4,
     )
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -188,12 +188,12 @@ jobs:
           git checkout main;
           [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
-        uses: NathanielRN/github-action-benchmark@v1.8.3-alpha3
+        uses: benchmark-action/github-action-benchmark@v1
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:
           name: Soak Test Results - sample-app-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
-          tool: custombenchmark
+          tool: customSmallerIsBetter
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           max-items-in-chart: ${{ env.MAX_BENCHMARKS_TO_KEEP }}
@@ -217,6 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
+          update_existing: true
       - name: Publish Issue if failed AFTER Performance Tests
         uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event_name == 'schedule' &&
@@ -227,6 +228,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/auto-issue-templates/failure-after-soak_tests.md
+          update_existing: true
       - name: Check for Performance Degradation either DURING or AFTER Performance Tests
         if: ${{ steps.check-failure-during-performance-tests.outcome == 'failure' ||
           steps.check-failure-after-performance-tests.outcome == 'failure' }}


### PR DESCRIPTION
# Description

Two updates to the Soak Tests are introduced in this PR:

1. We were super fortunate to get upstream's help to get our modifications to the `benchmark-action/github-action-benchmark` GitHub action merged and released upstream in https://github.com/benchmark-action/github-action-benchmark/pull/81 ! This way, we can use their action instead of my fork 😄 
2. Following https://github.com/aws-observability/aws-otel-java-instrumentation/pull/101#issuecomment-945999532 we found that instead of creating multiple issues when one benchmarking issue is detected, we would be better off updating the existing issue using a feature already available from the GitHub action we use. This way we will only have one issue for multiple failed Soak Test runs from a schedule instead of multiple issues.
