### PR TITLE
GitHub OIDC for AWS Creds in all workflows

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -5,6 +5,8 @@ jobs:
   Test_Integration_App:
     name: Integration Test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       ECR_REPO: public.ecr.aws/u0d6r4y4/aws-otel-dotnet-test
     steps:
@@ -15,8 +17,6 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       issues: write
     strategy:
       fail-fast: false
@@ -88,8 +89,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 21600 # 6 Hours
           aws-region: ${{ env.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
## Description

Like https://github.com/aws-observability/aws-otel-java-instrumentation/pull/130, we want to use GitHub OIDC for our AWS credentials in all workflows instead of using long-lasting credentials. This way, we can delete the repository secrets for AWS creds.

~**BLOCKED ON**: Updates to the IAM config. See this comment: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/130#issuecomment-996448781~ Unblocked!