### PR TITLE
Change from env var to volume mount for AWS creds

### DIFF
--- a/integration-test-app/README.md
+++ b/integration-test-app/README.md
@@ -18,7 +18,9 @@ This application **lacks** dependencies for AWS X-Ray trace id generator, propag
 
 1. Checkout `aws-otel-dotnet` repo and navigate to the `integration-test-app/` folder.
 
-2. In the same folder, replace the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values with your AWS credentials in `docker-compose.yml` file and run:
+2. Ensure that you have AWS credentials [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
+   
+`note`: Windows users will need to change the the volume mount source path for AWS credentials from `~/.aws` to `%USERPROFILE%\.aws`
 
 ```shell
 docker build -t aspnetapp .

--- a/integration-test-app/docker-compose.yml
+++ b/integration-test-app/docker-compose.yml
@@ -4,19 +4,16 @@ services:
     image: amazon/aws-otel-collector:latest
     command: --config /config/collector-config-local.yml
     volumes:
+      - ~/.aws:/root/.aws:ro
       - .:/config
     environment:
-      - AWS_ACCESS_KEY_ID=<your_AWS_ACCESS_KEY_ID>
-      - AWS_SECRET_ACCESS_KEY=<your_AWS_SECRET_ACCESS_KEY>
       - AWS_REGION=us-west-2
     ports:
       - '4317:4317'
 
   app:
     image: aspnetapp:latest
-    environment:
-      - AWS_ACCESS_KEY_ID=<your_AWS_ACCESS_KEY_ID>
-      - AWS_SECRET_ACCESS_KEY=<your_AWS_SECRET_ACCESS_KEY>
+    environment: 
       - AWS_REGION=us-west-2
       - INSTANCE_ID
       - LISTEN_ADDRESS=0.0.0.0:8080
@@ -24,4 +21,6 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
       - ASPNETCORE_URLS=http://+:8080
     ports:
-      - '8080:8080'      
+      - '8080:8080'     
+    volumes:
+      - ~/.aws:/root/.aws:ro


### PR DESCRIPTION
**Description:** This PR changes the way AWS credentials are provided to the `docker-compose` file used for local testing. Instead of having a user manually paste in AWS credentials the docker-compose file will mount the `~/.aws` configuration directory. This change should reduce the risk of accidentally committing secrets to the docker compose file. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
